### PR TITLE
Made portfolio not scroll when dragging through graph

### DIFF
--- a/Mobile/stockdogmobile/routes.js
+++ b/Mobile/stockdogmobile/routes.js
@@ -22,8 +22,8 @@ const Routes = () => (
    <Provider store={store}>
       <CustomRouter>
          <Scene key="root" hideNavBar>
-            {/* <Scene key="login" component={Login}/>
-            <Scene key="register" component={Register}/> */}
+            <Scene key="login" component={Login}/>
+            <Scene key="register" component={Register}/>
             {/* <Drawer
               key="drawer"  
               contentComponent={LeagueDrawer} 

--- a/Mobile/stockdogmobile/routes.js
+++ b/Mobile/stockdogmobile/routes.js
@@ -22,8 +22,8 @@ const Routes = () => (
    <Provider store={store}>
       <CustomRouter>
          <Scene key="root" hideNavBar>
-            <Scene key="login" component={Login}/>
-            <Scene key="register" component={Register}/>
+            {/* <Scene key="login" component={Login}/>
+            <Scene key="register" component={Register}/> */}
             {/* <Drawer
               key="drawer"  
               contentComponent={LeagueDrawer} 

--- a/Mobile/stockdogmobile/screens/portfolio.js
+++ b/Mobile/stockdogmobile/screens/portfolio.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Text, ScrollView } from 'react-native';
+import { View, Text, ScrollView, TouchableWithoutFeedback } from 'react-native';
 import { ButtonGroup } from 'react-native-elements';
 import containers from '../style/containers';
 import text from '../style/text';
@@ -8,18 +8,30 @@ import NavBar from '../components/navbar';
 import PortfolioStockList from '../components/portfolioStockList';
 
 export default class Portfolio extends Component {
+   constructor(props) {
+      super(props);
+      this.state = {
+         scrollEnabled: true
+      }
+   }
 
    render() {
       return (
          <View style={containers.profileBackground}>
-            <ScrollView scrollEnabled={true}>
+            <ScrollView scrollEnabled={this.state.scrollEnabled}>
                <View style={containers.profileBackgroundCircle}></View>
                <NavBar/>
                <View style={{flex: 0.9, alignItems: 'center'}}>
                   <View style={containers.portfolioValue}>
                      <Text style={text.value}>$20.05</Text>
                   </View>
-                  <StockChart />
+                  <TouchableWithoutFeedback
+                     onPressIn={() => {this.setState({scrollEnabled: false})}}
+                     onPressOut={() => {this.setState({scrollEnabled: true})}}>
+                     <View>
+                        <StockChart />
+                     </View>
+                  </TouchableWithoutFeedback>
                   <ButtonGroup
                      // onPress={this.updateIndex.bind(this)}
                      selectedIndex={0}


### PR DESCRIPTION
When you pressed and dragged on the graph in the portfolio page it used to also scroll the whole page with it. This change makes it so that when the graph is touched, scrolling is disabled for the page.